### PR TITLE
Show version in the window title

### DIFF
--- a/src/FF7Scarlet.csproj
+++ b/src/FF7Scarlet.csproj
@@ -9,6 +9,8 @@
     <ApplicationIcon>scarlet_icon.ico</ApplicationIcon>
     <AssemblyName>Scarlet</AssemblyName>
     <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
+    <Version>0.0.0</Version>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/StartupForm.cs
+++ b/src/StartupForm.cs
@@ -9,6 +9,8 @@ namespace FF7Scarlet
         public StartupForm()
         {
             InitializeComponent();
+            this.Text = $"{Application.ProductName} v{Application.ProductVersion} - Main Menu";
+
             DataManager.SetStartupForm(this);
             toolTipHoverText.SetToolTip(groupBoxKernel2, "kernel2 cannot be loaded without kernel.bin.");
 


### PR DESCRIPTION
This PR will add the version in the title, see the following screenshot as an example

![image](https://github.com/petfriendamy/ff7-scarlet/assets/1237070/2e7f0c6f-b46a-49f0-8aaa-0fbb06dd1b15)

Of course when built by CI, the `v0.0.0` will be replaced by the version you're publishing ( for eg. `v0.9.0.x` for canaries )