### PR TITLE
Fix materia level bug

### DIFF
--- a/src/KernelEditor/Controls/MateriaLevelControl.cs
+++ b/src/KernelEditor/Controls/MateriaLevelControl.cs
@@ -82,6 +82,10 @@
                     {
                         MaxLevel = i;
                     }
+                    if(i > MaxLevel)
+                    {
+                        MaxLevel = i;
+                    }
                     APSelectors[index].Value = value;
                     prevValues[index] = value;
                 }


### PR DESCRIPTION
In the kernel editor, if you switched from a materia with max level less than five to one with max level five, it'd be displayed as having a max of four. This fixes that.