### PR TITLE
Fix for adding AI Script conditional blocks with exit label ID < 16

### DIFF
--- a/src/AIEditor/CodeBlock.cs
+++ b/src/AIEditor/CodeBlock.cs
@@ -177,7 +177,7 @@ namespace FF7Scarlet.AIEditor
                         pop1 = block[1] as CodeLine;
                         if (pop1 != null && pop1.Parameter != null)
                         {
-                            sb.Append($"If ({block[0].Disassemble(jpText, false)}) (else goto label {BitConverter.ToUInt16(pop1.Parameter)})");
+                            sb.Append($"If ({block[0].Disassemble(jpText, false)}) (else goto label {BitConverter.ToUInt16(pop1.Parameter.Length == 1 ? [0x00, pop1.Parameter[0]] : pop1.Parameter)})");
                         }
                         break;
                     case Opcodes.JumpNotEqual:


### PR DESCRIPTION
When adding a conditional block to an AI Script in the Scene Editor, an exit Label ID value of 15 or less causes a crash. This crash traces back to BitConverter.ToUInt16 requiring at least a 2-byte byte span. Zero-padding the span when its length is less than 2 prevents the crash.

It looks like this issue exists elsewhere, but I'm not familiar enough with the app code to identify at present the best common code path where we can pad the byte span for all use cases.