### PR TITLE
Parameter Type Filtering Proof of Concept

### DIFF
--- a/src/AIEditor/CommonVarInfo.cs
+++ b/src/AIEditor/CommonVarInfo.cs
@@ -1,0 +1,18 @@
+namespace FF7Scarlet.AIEditor
+{
+    public class CommonVarInfo<T>(T global, Opcodes type)
+    {
+        public static readonly CommonVarInfo<CommonVars.Globals>[] GLOBALS_LIST =
+        [
+            new CommonVarInfo<CommonVars.Globals>(CommonVars.Globals.Self, Opcodes.PushAddress02),
+            new CommonVarInfo<CommonVars.Globals>(CommonVars.Globals.Target, Opcodes.PushValue12),
+        ];
+
+        public static readonly CommonVarInfo<CommonVars.ActorGlobals>[] ACTOR_GLOBALS_LIST = [
+            new CommonVarInfo<CommonVars.ActorGlobals>(CommonVars.ActorGlobals.Target, Opcodes.PushAddress02),
+        ];
+
+        public T EnumValue { get; } = global;
+        public Opcodes Type { get; } = type;
+    }
+}

--- a/src/AIEditor/CommonVarInfo.cs
+++ b/src/AIEditor/CommonVarInfo.cs
@@ -3,7 +3,7 @@ namespace FF7Scarlet.AIEditor
     public class CommonVarInfo
     {
         public static readonly CommonVarInfo[] GLOBALS_LIST = [
-            new CommonVarInfo(CommonVars.Globals.Self, Opcodes.PushAddress02)
+            new CommonVarInfo(CommonVars.Globals.Self, Opcodes.PushValue12)
         ];
         public static readonly CommonVarInfo[] ACTOR_GLOBALS_LIST = [];
 

--- a/src/AIEditor/CommonVarInfo.cs
+++ b/src/AIEditor/CommonVarInfo.cs
@@ -2,7 +2,9 @@ namespace FF7Scarlet.AIEditor
 {
     public class CommonVarInfo
     {
-        public static readonly CommonVarInfo[] GLOBALS_LIST = [];
+        public static readonly CommonVarInfo[] GLOBALS_LIST = [
+            new CommonVarInfo(CommonVars.Globals.Self, Opcodes.PushAddress02)
+        ];
         public static readonly CommonVarInfo[] ACTOR_GLOBALS_LIST = [];
 
         public Enum Global { get; }

--- a/src/AIEditor/CommonVarInfo.cs
+++ b/src/AIEditor/CommonVarInfo.cs
@@ -3,23 +3,23 @@ namespace FF7Scarlet.AIEditor
     public class CommonVarInfo
     {
         public static readonly CommonVarInfo[] GLOBALS_LIST = [
-            new CommonVarInfo(CommonVars.Globals.Self, Opcodes.PushValue12)
+            new CommonVarInfo(CommonVars.Globals.Self, [Opcodes.PushAddress02, Opcodes.PushValue12])
         ];
         public static readonly CommonVarInfo[] ACTOR_GLOBALS_LIST = [];
 
         public Enum Global { get; }
-        public Opcodes Type { get; }
+        public Opcodes[] Types { get; }
 
-        public CommonVarInfo(CommonVars.Globals global, Opcodes type)
+        public CommonVarInfo(CommonVars.Globals global, Opcodes[] types)
         {
             Global = global;
-            Type = type;
+            Types = types;
         }
 
-        public CommonVarInfo(CommonVars.ActorGlobals global, Opcodes type)
+        public CommonVarInfo(CommonVars.ActorGlobals global, Opcodes[] types)
         {
             Global = global;
-            Type = type;
+            Types = types;
         }
 
         public string? GetEnumValueName() => Enum.GetName(Global.GetType(), Global);

--- a/src/AIEditor/CommonVarInfo.cs
+++ b/src/AIEditor/CommonVarInfo.cs
@@ -1,18 +1,25 @@
 namespace FF7Scarlet.AIEditor
 {
-    public class CommonVarInfo<T>(T global, Opcodes type)
+    public class CommonVarInfo
     {
-        public static readonly CommonVarInfo<CommonVars.Globals>[] GLOBALS_LIST =
-        [
-            new CommonVarInfo<CommonVars.Globals>(CommonVars.Globals.Self, Opcodes.PushAddress02),
-            new CommonVarInfo<CommonVars.Globals>(CommonVars.Globals.Target, Opcodes.PushValue12),
-        ];
+        public static readonly CommonVarInfo[] GLOBALS_LIST = [];
+        public static readonly CommonVarInfo[] ACTOR_GLOBALS_LIST = [];
 
-        public static readonly CommonVarInfo<CommonVars.ActorGlobals>[] ACTOR_GLOBALS_LIST = [
-            new CommonVarInfo<CommonVars.ActorGlobals>(CommonVars.ActorGlobals.Target, Opcodes.PushAddress02),
-        ];
+        public Enum Global { get; }
+        public Opcodes Type { get; }
 
-        public T EnumValue { get; } = global;
-        public Opcodes Type { get; } = type;
-    }
+        public CommonVarInfo(CommonVars.Globals global, Opcodes type)
+        {
+            Global = global;
+            Type = type;
+        }
+
+        public CommonVarInfo(CommonVars.ActorGlobals global, Opcodes type)
+        {
+            Global = global;
+            Type = type;
+        }
+
+        public string? GetEnumValueName() => Enum.GetName(Global.GetType(), Global);
+    };
 }

--- a/src/AIEditor/ParameterControl.cs
+++ b/src/AIEditor/ParameterControl.cs
@@ -268,16 +268,18 @@ namespace FF7Scarlet.AIEditor
             comboBoxType.Items.Clear();
             if (deezGlobals.Any())
             {
-                var deezOpcodes =
-                (from op in deezGlobals
-                 select op.Type);
-                validTypes = (from op in paramTypes
-                              where deezOpcodes.Contains(op.EnumValue)
-                              select op).ToList();
-
+                validTypes = [];
                 foreach (var global in deezGlobals)
                 {
-                    comboBoxType.Items.Add(paramTypes.Single(eachParamType => eachParamType.EnumValue == global.Type).ShortName);
+                    foreach (var op in global.Types)
+                    {
+                        var info = OpcodeInfo.GetInfo(op);
+                        if (info != null)
+                        {
+                            validTypes.Add(info);
+                            comboBoxType.Items.Add(paramTypes.Single(eachParamType => eachParamType.EnumValue == op).ShortName);
+                        }
+                    }
                 }
             }
             else

--- a/src/AIEditor/ParameterControl.cs
+++ b/src/AIEditor/ParameterControl.cs
@@ -241,6 +241,30 @@ namespace FF7Scarlet.AIEditor
             {
                 comboBoxParameter.Items.Add(gv);
             }
+            comboBoxParameter.SelectionChangeCommitted += (sender, arguments) =>
+            {
+                var globals = CommonVarInfo<CommonVars.Globals>.GLOBALS_LIST.Where(eachGlobal =>
+                {
+                    var globalName = Enum.GetName(eachGlobal.EnumValue);
+                    return globalName is not null && globalName.Equals(comboBoxParameter.SelectedItem?.ToString(), StringComparison.OrdinalIgnoreCase);
+                });
+                var actorGlobals = CommonVarInfo<CommonVars.ActorGlobals>.ACTOR_GLOBALS_LIST.Where(eachGlobal =>
+                {
+                    var globalName = Enum.GetName(eachGlobal.EnumValue);
+                    return globalName is not null && globalName.Equals(comboBoxParameter.SelectedItem?.ToString(), StringComparison.OrdinalIgnoreCase);
+                });
+                comboBoxType.BeginUpdate();
+                comboBoxType.Items.Clear();
+                foreach (var global in globals)
+                {
+                    comboBoxType.Items.Add(paramTypes.Single(eachParamType => eachParamType.EnumValue == global.Type).ShortName);
+                }
+                foreach (var actorGlobal in actorGlobals)
+                {
+                    comboBoxType.Items.Add(paramTypes.Single(eachParamType => eachParamType.EnumValue == actorGlobal.Type).ShortName);
+                }
+                comboBoxType.EndUpdate();
+            };
             comboBoxParameter.EndUpdate();
             loading = false;
         }

--- a/src/AIEditor/ParameterControl.cs
+++ b/src/AIEditor/ParameterControl.cs
@@ -12,6 +12,7 @@ namespace FF7Scarlet.AIEditor
         #region Properties
 
         private readonly List<OpcodeInfo> operands, modifiers, paramTypes;
+        private List<OpcodeInfo> validTypes;
         private byte operand = 0xFF, modifier = 0xFF, paramType = 0xFF;
         private bool singleParameter = false, modifyAbove = false, jpText, loading = true;
 
@@ -62,7 +63,7 @@ namespace FF7Scarlet.AIEditor
                 }
                 else if (!singleParameter && comboBoxType.SelectedIndex != -1)
                 {
-                    return paramTypes[comboBoxType.SelectedIndex].Code;
+                    return validTypes[comboBoxType.SelectedIndex].Code;
                 }
                 else { return paramType; }
             }
@@ -208,6 +209,8 @@ namespace FF7Scarlet.AIEditor
                             && op.ParameterType != ParameterTypes.Debug)
                           select op).ToList();
 
+            validTypes = [.. paramTypes];
+
             comboBoxOperand.BeginUpdate();
             foreach (var op in operands)
             {
@@ -252,6 +255,8 @@ namespace FF7Scarlet.AIEditor
 
         private void FilterTypeByParameter(List<OpcodeInfo> paramTypes, string? parameterName)
         {
+            var currType = OpcodeInfo.GetInfo(ParamType);
+
             List<CommonVarInfo> allGlobals = [.. CommonVarInfo.GLOBALS_LIST];
             allGlobals.AddRange(CommonVarInfo.ACTOR_GLOBALS_LIST);
             var deezGlobals = allGlobals.Where(eachGlobal =>
@@ -263,6 +268,13 @@ namespace FF7Scarlet.AIEditor
             comboBoxType.Items.Clear();
             if (deezGlobals.Any())
             {
+                var deezOpcodes =
+                (from op in deezGlobals
+                 select op.Type);
+                validTypes = (from op in paramTypes
+                              where deezOpcodes.Contains(op.EnumValue)
+                              select op).ToList();
+
                 foreach (var global in deezGlobals)
                 {
                     comboBoxType.Items.Add(paramTypes.Single(eachParamType => eachParamType.EnumValue == global.Type).ShortName);
@@ -270,6 +282,7 @@ namespace FF7Scarlet.AIEditor
             }
             else
             {
+                validTypes = [.. paramTypes];
                 foreach (var op in paramTypes)
                 {
                     comboBoxType.Items.Add(op.ShortName);
@@ -277,6 +290,14 @@ namespace FF7Scarlet.AIEditor
                 comboBoxType.Items.Add("(Modify above)");
             }
             comboBoxType.EndUpdate();
+
+            //re-select the previous opcode (if still valid)
+            int i = 0;
+            if (currType != null)
+            {
+                i = Math.Max(0, validTypes.IndexOf(currType));
+            }
+            comboBoxType.SelectedIndex = i;
         }
 
         public void SetAsFirst()

--- a/src/AIEditor/ParameterControl.cs
+++ b/src/AIEditor/ParameterControl.cs
@@ -241,30 +241,7 @@ namespace FF7Scarlet.AIEditor
             {
                 comboBoxParameter.Items.Add(gv);
             }
-            comboBoxParameter.SelectionChangeCommitted += (sender, arguments) =>
-            {
-                var globals = CommonVarInfo<CommonVars.Globals>.GLOBALS_LIST.Where(eachGlobal =>
-                {
-                    var globalName = Enum.GetName(eachGlobal.EnumValue);
-                    return globalName is not null && globalName.Equals(comboBoxParameter.SelectedItem?.ToString(), StringComparison.OrdinalIgnoreCase);
-                });
-                var actorGlobals = CommonVarInfo<CommonVars.ActorGlobals>.ACTOR_GLOBALS_LIST.Where(eachGlobal =>
-                {
-                    var globalName = Enum.GetName(eachGlobal.EnumValue);
-                    return globalName is not null && globalName.Equals(comboBoxParameter.SelectedItem?.ToString(), StringComparison.OrdinalIgnoreCase);
-                });
-                comboBoxType.BeginUpdate();
-                comboBoxType.Items.Clear();
-                foreach (var global in globals)
-                {
-                    comboBoxType.Items.Add(paramTypes.Single(eachParamType => eachParamType.EnumValue == global.Type).ShortName);
-                }
-                foreach (var actorGlobal in actorGlobals)
-                {
-                    comboBoxType.Items.Add(paramTypes.Single(eachParamType => eachParamType.EnumValue == actorGlobal.Type).ShortName);
-                }
-                comboBoxType.EndUpdate();
-            };
+            comboBoxParameter.SelectionChangeCommitted += (sender, arguments) => FilterTypeByParameter(paramTypes, comboBoxParameter.SelectedItem?.ToString());
             comboBoxParameter.EndUpdate();
             loading = false;
         }
@@ -272,6 +249,35 @@ namespace FF7Scarlet.AIEditor
         #endregion
 
         #region User Methods
+
+        private void FilterTypeByParameter(List<OpcodeInfo> paramTypes, string? parameterName)
+        {
+            List<CommonVarInfo> allGlobals = [.. CommonVarInfo.GLOBALS_LIST];
+            allGlobals.AddRange(CommonVarInfo.ACTOR_GLOBALS_LIST);
+            var deezGlobals = allGlobals.Where(eachGlobal =>
+            {
+                var globalName = eachGlobal.GetEnumValueName();
+                return globalName is not null && globalName.Equals(parameterName, StringComparison.OrdinalIgnoreCase);
+            });
+            comboBoxType.BeginUpdate();
+            comboBoxType.Items.Clear();
+            if (deezGlobals.Any())
+            {
+                foreach (var global in deezGlobals)
+                {
+                    comboBoxType.Items.Add(paramTypes.Single(eachParamType => eachParamType.EnumValue == global.Type).ShortName);
+                }
+            }
+            else
+            {
+                foreach (var op in paramTypes)
+                {
+                    comboBoxType.Items.Add(op.ShortName);
+                }
+                comboBoxType.Items.Add("(Modify above)");
+            }
+            comboBoxType.EndUpdate();
+        }
 
         public void SetAsFirst()
         {


### PR DESCRIPTION
Proof of a mechanism to filter the Type drop-down by the selected Parameter value's associated type. If the selected Parameter's Type isn't included in CommonVarInfo, the default list of all Types is presented.

It only works when the user directly selects an item from the Parameter drop-down; it doesn't work when the value is pre-filled (e.g. loading from an existing script) or when the user manually types the Parameter value. This may be seen as desirable since it allows verifying Types from existing scripts and bypassing the Type filter if needed.

All Types associated with a Parameter name matching the selected name are included: if the same Parameter name is in Globals and Actor Globals (e.g. Target,) both associated Types will appear.